### PR TITLE
ci: add automated stale branch cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+name: CI
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: Jaureguy760/shared-workflows/.github/workflows/ci-python.yml@main
+    with:
+      python-version: '3.11'

--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -1,0 +1,12 @@
+name: Stale Branch Cleanup
+on:
+  schedule:
+    - cron: '0 3 * * 0'  # Weekly on Sunday at 3am UTC
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    uses: Jaureguy760/shared-workflows/.github/workflows/stale-branches.yml@main
+    with:
+      days-stale: 14
+      exclude-branches: 'main,master,dev,develop'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,8 @@
+name: Stale Issues
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 6am UTC
+
+jobs:
+  stale:
+    uses: Jaureguy760/shared-workflows/.github/workflows/stale-issues.yml@main


### PR DESCRIPTION
Adds weekly stale-branches.yml workflow that auto-deletes branches with no commits in 14+ days. Uses Jaureguy760/shared-workflows reusable workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily CI/maintenance automation, but it can delete branches automatically and depends on external reusable workflows, so misconfiguration could cause unwanted branch cleanup or workflow behavior changes.
> 
> **Overview**
> Introduces GitHub Actions automation by adding a `CI` workflow that runs on pushes/PRs using a reusable `ci-python.yml` workflow pinned to Python `3.11`.
> 
> Adds scheduled repo hygiene workflows: a weekly `stale-branches.yml` job (also manually triggerable) that auto-deletes branches with no commits in 14+ days while excluding `main, master, dev, develop`, and a weekly `stale.yml` workflow for marking/handling stale issues via a shared workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b275c305e3e056c78bfe861608783df708e7269b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->